### PR TITLE
Swt26 g08/logic graph

### DIFF
--- a/src/SqueakKara-Core/SKContextVariables.class.st
+++ b/src/SqueakKara-Core/SKContextVariables.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #SKContextVariables,
+	#superclass : #Dictionary,
+	#instVars : [
+		'dictionary'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:59'
+}
+SKContextVariables >> at: aKey [
+
+	(self dictionary includesKey: aKey) ifFalse: [
+			self dictionary at: aKey put: nil.
+			Transcript show: '[ContextVariables] Key not found'; cr].
+		
+	^ self dictionary at: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:44'
+}
+SKContextVariables >> at: aKey put: aValue [
+
+	self dictionary at: aKey put: aValue
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:41'
+}
+SKContextVariables >> dictionary [
+
+	^ dictionary ifNil: [dictionary := Dictionary new]
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:26'
+}
+SKContextVariables >> includes: aKey [
+
+	^ self dictionary includes: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:27'
+}
+SKContextVariables >> includesKey: aKey [
+
+	^ self dictionary includesKey: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:41'
+}
+SKContextVariables >> reset [
+	
+	dictionary := nil 
+]

--- a/src/SqueakKara-Core/SKEnvironment.class.st
+++ b/src/SqueakKara-Core/SKEnvironment.class.st
@@ -12,7 +12,8 @@ Class {
 		'executeControls',
 		'gameWidth',
 		'gameHeight',
-		'systemWindow'
+		'systemWindow',
+		'logicGraph'
 	],
 	#category : #'SqueakKara-Core',
 	#'squeak_changestamp' : 'JJG 7/1/2024 15:38'

--- a/src/SqueakKara-Core/SKExecuteContext.class.st
+++ b/src/SqueakKara-Core/SKExecuteContext.class.st
@@ -7,11 +7,30 @@ Class {
 	#instVars : [
 		'kara',
 		'right',
-		'left'
+		'left',
+		'env'
 	],
 	#category : #'SqueakKara-Core',
 	#'squeak_changestamp' : 'JJG 7/1/2024 15:41'
 }
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:42'
+}
+SKExecuteContext >> env [
+
+	^ env
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:04'
+}
+SKExecuteContext >> env: aDictonary [
+
+	env := aDictonary
+]
 
 {
 	#category : #initialization,

--- a/src/SqueakKara-Core/SKExecuteContext.class.st
+++ b/src/SqueakKara-Core/SKExecuteContext.class.st
@@ -25,7 +25,7 @@ SKExecuteContext >> initialize [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'JJG 6/17/2024 16:40'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:05'
 }
 SKExecuteContext >> kara: anObject [
 	

--- a/src/SqueakKara-Core/SKLogicEdge.class.st
+++ b/src/SqueakKara-Core/SKLogicEdge.class.st
@@ -2,19 +2,61 @@ Class {
 	#name : #SKLogicEdge,
 	#superclass : #Object,
 	#instVars : [
-		'inNode',
-		'outNode',
+		'toNode',
+		'fromNode',
 		'command',
-		'condition'
+		'condition',
+		'hasDefaultCondition'
 	],
 	#category : #'SqueakKara-Core'
 }
 
 {
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:52'
+}
+SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: aLogicNode inNode: anotherLogicNode [
+
+	^(self new
+		command: aString;
+		condition: anotherString;
+		outNode: aLogicNode;
+		inNode: anotherLogicNode;
+		yourself)
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:43'
+}
+SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: anotherLogicNode [
+
+	^(self new
+		command: aString;
+		condition: anotherString;
+		toNode: anotherLogicNode;
+		yourself)
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:01'
+}
+SKLogicEdge class >> newWithOutNode: aLogicNode inNode: anotherLogicNode [
+
+	^ (self new
+		outNode: aLogicNode;
+		inNode: anotherLogicNode;
+		yourself)
+]
+
+{
 	#category : #visitor,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:25'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:37'
 }
 SKLogicEdge >> accept: aVisitor [
+
+	aVisitor visitLogicEdge: self
 ]
 
 {
@@ -37,54 +79,73 @@ SKLogicEdge >> command: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:27'
 }
 SKLogicEdge >> condition [
 
-	^ condition ifNil: [ condition := 'default' ]
+	^ condition ifNil: [ condition := '' ]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:30'
 }
 SKLogicEdge >> condition: aString [
 
+	self toggleHasNoDefaultCondition.
 	condition := aString
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> inNode [
+SKLogicEdge >> fromNode [
 
-	^ inNode
+	^ fromNode
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> inNode: aLogicNode [
+SKLogicEdge >> fromNode: aLogicNode [
 
-	inNode := aLogicNode
+	fromNode := aLogicNode
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:46'
 }
-SKLogicEdge >> outNode [
-
-	^ outNode
+SKLogicEdge >> hasDefaultCondition [
+	
+	^ hasDefaultCondition ifNil: [hasDefaultCondition := true]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> outNode: aLogicNode [
+SKLogicEdge >> toNode [
 
-	outNode := aLogicNode
+	^ toNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:45'
+}
+SKLogicEdge >> toNode: aLogicNode [
+
+	toNode := aLogicNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:29'
+}
+SKLogicEdge >> toggleHasNoDefaultCondition [
+
+	hasDefaultCondition := false
 ]

--- a/src/SqueakKara-Core/SKLogicEdge.class.st
+++ b/src/SqueakKara-Core/SKLogicEdge.class.st
@@ -13,9 +13,9 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:52'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:19'
 }
-SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: aLogicNode inNode: anotherLogicNode [
+SKLogicEdge class >> newWithCommand: aString condition: anotherString fromNode: aLogicNode toNode: anotherLogicNode [
 
 	^(self new
 		command: aString;
@@ -27,36 +27,27 @@ SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: a
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:43'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:30'
 }
-SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: anotherLogicNode [
+SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: aLogicNode [
 
 	^(self new
 		command: aString;
 		condition: anotherString;
-		toNode: anotherLogicNode;
+		toNode: aLogicNode;
 		yourself)
 ]
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:01'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:19'
 }
-SKLogicEdge class >> newWithOutNode: aLogicNode inNode: anotherLogicNode [
+SKLogicEdge class >> newWithfromNode: aLogicNode toNode: anotherLogicNode [
 
 	^ (self new
 		outNode: aLogicNode;
 		inNode: anotherLogicNode;
 		yourself)
-]
-
-{
-	#category : #visitor,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:37'
-}
-SKLogicEdge >> accept: aVisitor [
-
-	aVisitor visitLogicEdge: self
 ]
 
 {
@@ -88,11 +79,11 @@ SKLogicEdge >> condition [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:30'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:50'
 }
 SKLogicEdge >> condition: aString [
 
-	self toggleHasNoDefaultCondition.
+	(aString  ~= '') ifTrue: [self toggleHasNoDefaultCondition].
 	condition := aString
 ]
 

--- a/src/SqueakKara-Core/SKLogicEdge.class.st
+++ b/src/SqueakKara-Core/SKLogicEdge.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : #SKLogicEdge,
+	#superclass : #Object,
+	#instVars : [
+		'inNode',
+		'outNode',
+		'command',
+		'condition'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #visitor,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:25'
+}
+SKLogicEdge >> accept: aVisitor [
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:24'
+}
+SKLogicEdge >> command [
+
+	^ command ifNil: [ command := '' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:22'
+}
+SKLogicEdge >> command: aString [
+
+	command := aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+}
+SKLogicEdge >> condition [
+
+	^ condition ifNil: [ condition := 'default' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+}
+SKLogicEdge >> condition: aString [
+
+	condition := aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> inNode [
+
+	^ inNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> inNode: aLogicNode [
+
+	inNode := aLogicNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> outNode [
+
+	^ outNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> outNode: aLogicNode [
+
+	outNode := aLogicNode
+]

--- a/src/SqueakKara-Core/SKLogicGraph.class.st
+++ b/src/SqueakKara-Core/SKLogicGraph.class.st
@@ -8,6 +8,17 @@ Class {
 }
 
 {
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:54'
+}
+SKLogicGraph class >> newWithStartingNode: aLogicNode [
+	
+	^ (self new
+		startingNode: aLogicNode;
+		yourself)
+]
+
+{
 	#category : #accessing,
 	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
 }

--- a/src/SqueakKara-Core/SKLogicGraph.class.st
+++ b/src/SqueakKara-Core/SKLogicGraph.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : #SKLogicGraph,
 	#superclass : #Object,
 	#instVars : [
-		'startingNode'
+		'startingNode',
+		'nodes',
+		'edges'
 	],
 	#category : #'SqueakKara-Core'
 }
@@ -16,6 +18,86 @@ SKLogicGraph class >> newWithStartingNode: aLogicNode [
 	^ (self new
 		startingNode: aLogicNode;
 		yourself)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:09'
+}
+SKLogicGraph >> addEdge: aLogicEdge [
+
+	self edges at: (aLogicEdge toNode name) put: aLogicEdge
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:18'
+}
+SKLogicGraph >> addEdgeFrom: aFromString to: aToString command: aCommandString condition: aConditionString [
+
+	 | fromNode toNode edge|
+	
+	fromNode := self getNodeByName: aFromString.
+	toNode := self getNodeByName: aToString.
+	edge := fromNode addEdge: (SKLogicEdge newWithCommand: aCommandString condition: aConditionString toNode: toNode).
+	self addEdge: edge	
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:09'
+}
+SKLogicGraph >> addNode: aLogicNode [
+
+	self nodes at: (aLogicNode name) put: aLogicNode
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:04'
+}
+SKLogicGraph >> addNodeWithName: aString [
+
+	self addNode: (SKLogicNode newWithName: aString)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:11'
+}
+SKLogicGraph >> edges [
+
+	^ edges ifNil: [edges := Dictionary new]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:25'
+}
+SKLogicGraph >> getNodeByName: aString [ 
+
+	(self nodes includesKey: aString) ifFalse: [
+		self error:  '[LogicGraph] No node found with name: ' , aString.
+		^ nil].
+	^ self nodes at: aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:08'
+}
+SKLogicGraph >> nodes [
+
+	^ nodes ifNil: [nodes := Dictionary new]
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:31'
+}
+SKLogicGraph >> setStartNode: aString [
+
+	self startingNode: (self getNodeByName: aString)
 ]
 
 {

--- a/src/SqueakKara-Core/SKLogicGraph.class.st
+++ b/src/SqueakKara-Core/SKLogicGraph.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #SKLogicGraph,
+	#superclass : #Object,
+	#instVars : [
+		'startingNode'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
+}
+SKLogicGraph >> startingNode [
+
+	^ startingNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
+}
+SKLogicGraph >> startingNode: aLogicNode [
+
+	startingNode := aLogicNode
+]

--- a/src/SqueakKara-Core/SKLogicNode.class.st
+++ b/src/SqueakKara-Core/SKLogicNode.class.st
@@ -9,21 +9,42 @@ Class {
 }
 
 {
-	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:18'
+	#category : #constructor,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:49'
 }
-SKLogicNode >> addEdge: aLogicEdge [
+SKLogicNode class >> newWithName: aString [
 	
-	edges add: aLogicEdge 
+	^ (self new
+		name: aString;
+		yourself)
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:47'
+}
+SKLogicNode >> addEdge: aLogicEdge [
+	
+	aLogicEdge fromNode: self.
+	self edges add: aLogicEdge 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:04'
 }
 SKLogicNode >> edges [
 
-	^ edges
+	^ edges ifNil: [edges := OrderedCollection new]
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:05'
+}
+SKLogicNode >> hasEdge [
+
+	^ (self edges size > 0)
 ]
 
 {

--- a/src/SqueakKara-Core/SKLogicNode.class.st
+++ b/src/SqueakKara-Core/SKLogicNode.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #SKLogicNode,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'edges'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:18'
+}
+SKLogicNode >> addEdge: aLogicEdge [
+	
+	edges add: aLogicEdge 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+}
+SKLogicNode >> edges [
+
+	^ edges
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+}
+SKLogicNode >> name [
+
+	^ name ifNil: [ name := '' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:14'
+}
+SKLogicNode >> name: aString [
+	
+	name := aString
+]

--- a/src/SqueakKara-Core/SKLogicNode.class.st
+++ b/src/SqueakKara-Core/SKLogicNode.class.st
@@ -21,12 +21,14 @@ SKLogicNode class >> newWithName: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:47'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:06'
 }
 SKLogicNode >> addEdge: aLogicEdge [
 	
 	aLogicEdge fromNode: self.
-	self edges add: aLogicEdge 
+	self edges add: aLogicEdge.
+	
+	^ aLogicEdge
 ]
 
 {

--- a/src/SqueakKara-Core/SKLogicRunner.class.st
+++ b/src/SqueakKara-Core/SKLogicRunner.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #SKLogicRunner,
+	#superclass : #Object,
+	#instVars : [
+		'currentNode'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:32'
+}
+SKLogicRunner >> currentNode [
+	
+	^ currentNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:32'
+}
+SKLogicRunner >> currentNode: aLogicNode [
+
+	currentNode := aLogicNode
+]

--- a/src/SqueakKara-Core/SKLogicRunner.class.st
+++ b/src/SqueakKara-Core/SKLogicRunner.class.st
@@ -11,25 +11,24 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:03'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:07'
 }
-SKLogicRunner class >> newWithKara: aKara [
+SKLogicRunner class >> newWithExecutionContext: aExecutionContext [
 
-	| runner |
-	
-	runner := self new.
-	runner executeContext kara: aKara.
-	^ runner
+	^ (self new
+		executeContext: aExecutionContext copy;
+		yourself)
 ]
 
 {
 	#category : #initialize,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:45'
 }
 SKLogicRunner >> attachToGraph: aLogicGraph [
 
 	Transcript show: '[LogicRunner] Attacht to startingNode: ' , aLogicGraph startingNode name; cr.
 
+	self executeContext env: (SKContextVariables new).
 	self compiler: (Compiler new);
 		currentNode: aLogicGraph startingNode 
 ]
@@ -81,11 +80,11 @@ SKLogicRunner >> executeCode: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:32'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 20:56'
 }
 SKLogicRunner >> executeContext [
 
-	^ executeContext ifNil: [executeContext := SKExecuteContext new]
+	^ executeContext
 ]
 
 {
@@ -99,7 +98,7 @@ SKLogicRunner >> executeContext: aExecuteContext [
 
 {
 	#category : #execution,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:07'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:55'
 }
 SKLogicRunner >> executeStep [
 	
@@ -117,7 +116,7 @@ SKLogicRunner >> executeStep [
 
 {
 	#category : #execution,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:14'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:55'
 }
 SKLogicRunner >> findNextEdge: aLogicNode [
 
@@ -145,13 +144,4 @@ SKLogicRunner >> traverseEdge: aLogicEdge [
 
 	self currentNode: aLogicEdge toNode
 	
-]
-
-{
-	#category : #visit,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:39'
-}
-SKLogicRunner >> visitLogicEdge: aLogicEdge [
-
-	self traverseEdge: aLogicEdge
 ]

--- a/src/SqueakKara-Core/SKLogicRunner.class.st
+++ b/src/SqueakKara-Core/SKLogicRunner.class.st
@@ -2,10 +2,55 @@ Class {
 	#name : #SKLogicRunner,
 	#superclass : #Object,
 	#instVars : [
-		'currentNode'
+		'currentNode',
+		'executeContext',
+		'compiler'
 	],
 	#category : #'SqueakKara-Core'
 }
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:03'
+}
+SKLogicRunner class >> newWithKara: aKara [
+
+	| runner |
+	
+	runner := self new.
+	runner executeContext kara: aKara.
+	^ runner
+]
+
+{
+	#category : #initialize,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+}
+SKLogicRunner >> attachToGraph: aLogicGraph [
+
+	Transcript show: '[LogicRunner] Attacht to startingNode: ' , aLogicGraph startingNode name; cr.
+
+	self compiler: (Compiler new);
+		currentNode: aLogicGraph startingNode 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:36'
+}
+SKLogicRunner >> compiler [
+
+	^ compiler
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:36'
+}
+SKLogicRunner >> compiler: aCompiler [
+
+	compiler := aCompiler
+]
 
 {
 	#category : #accessing,
@@ -23,4 +68,90 @@ SKLogicRunner >> currentNode [
 SKLogicRunner >> currentNode: aLogicNode [
 
 	currentNode := aLogicNode
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:40'
+}
+SKLogicRunner >> executeCode: aString [
+
+	^ (self compiler evaluate: aString for: self executeContext)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:32'
+}
+SKLogicRunner >> executeContext [
+
+	^ executeContext ifNil: [executeContext := SKExecuteContext new]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:21'
+}
+SKLogicRunner >> executeContext: aExecuteContext [
+	
+	^ executeContext := aExecuteContext
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:07'
+}
+SKLogicRunner >> executeStep [
+	
+	| nextEdge |
+	
+	self currentNode hasEdge ifFalse: [
+			Transcript show: '[LoigcRunner] ', currentNode name , ' has no edges'; cr.
+			^ nil].
+	nextEdge := self findNextEdge: self currentNode. 
+	nextEdge ifNil: [^ nil].
+	
+	self	executeCode: nextEdge command; 
+		traverseEdge: nextEdge
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:14'
+}
+SKLogicRunner >> findNextEdge: aLogicNode [
+
+	| possibleEdges defaultEdges result |
+	
+	possibleEdges := aLogicNode edges select: [:aEdge |
+			result := self executeCode: aEdge condition.
+			((aEdge hasDefaultCondition not) and: (result isBoolean)) and: result].
+	defaultEdges := aLogicNode edges select: [:aEdge | aEdge hasDefaultCondition].
+	
+	(possibleEdges size > 0) ifTrue: [^ possibleEdges first].
+	(defaultEdges size > 0) ifTrue: [^ defaultEdges first].
+	
+	Transcript show: '[LogicRunner] No possible edge found'; cr.
+	^ nil
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:45'
+}
+SKLogicRunner >> traverseEdge: aLogicEdge [
+
+	Transcript show: ('[LogicRunner] ' , aLogicEdge fromNode name, ' --> ', aLogicEdge toNode name); cr.
+
+	self currentNode: aLogicEdge toNode
+	
+]
+
+{
+	#category : #visit,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:39'
+}
+SKLogicRunner >> visitLogicEdge: aLogicEdge [
+
+	self traverseEdge: aLogicEdge
 ]

--- a/src/SqueakKara-Core/SKTestGround.class.st
+++ b/src/SqueakKara-Core/SKTestGround.class.st
@@ -6,22 +6,26 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:31'
 }
 SKTestGround >> testLogicGraphWithKara [
 
-	| node1 node2 edge12 graph runner grid kara | 
+	| graph runner grid kara executionContext | 
 	
-	node1 := SKLogicNode newWithName: 'node1'.
-	node2 := SKLogicNode newWithName: 'node2'.
-	edge12 := SKLogicEdge newWithCommand: 'kara move' condition: 'true' toNode: node2.
-	node1 addEdge: edge12.
-	graph := SKLogicGraph newWithStartingNode: node1.
+	graph := (SKLogicGraph new
+				addNodeWithName: 'node1';
+				addNodeWithName: 'node2';
+				addEdgeFrom: 'node1' to: 'node2' command: 'kara move. env at: #test put: true' condition: 'true';
+				addEdgeFrom: 'node2' to: 'node1' command: '' condition: 'env at: #test';
+				setStartNode: 'node1';
+				yourself).
 	
 	grid := SKGrid newWithExtent: 7@7.
 	kara := SKKara newInGrid: grid at: 1@1.
+	executionContext := SKExecuteContext new.
+	executionContext kara: kara.
 
-	runner := SKLogicRunner newWithKara: kara.
+	runner := SKLogicRunner newWithExecutionContext: executionContext.
 	runner attachToGraph: graph.
 
 	^ runner

--- a/src/SqueakKara-Core/SKTestGround.class.st
+++ b/src/SqueakKara-Core/SKTestGround.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #SKTestGround,
+	#superclass : #Object,
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+}
+SKTestGround >> testLogicGraphWithKara [
+
+	| node1 node2 edge12 graph runner grid kara | 
+	
+	node1 := SKLogicNode newWithName: 'node1'.
+	node2 := SKLogicNode newWithName: 'node2'.
+	edge12 := SKLogicEdge newWithCommand: 'kara move' condition: 'true' toNode: node2.
+	node1 addEdge: edge12.
+	graph := SKLogicGraph newWithStartingNode: node1.
+	
+	grid := SKGrid newWithExtent: 7@7.
+	kara := SKKara newInGrid: grid at: 1@1.
+
+	runner := SKLogicRunner newWithKara: kara.
+	runner attachToGraph: graph.
+
+	^ runner
+]

--- a/src/SqueakKara-Core/package.st
+++ b/src/SqueakKara-Core/package.st
@@ -1,4 +1,4 @@
 Package {
-	#name : #'SqueakKara-Core',
-	#'squeak_changestamp' : true
+	#'squeak_changestamp' : true,
+	#name : #'SqueakKara-Core'
 }

--- a/src/SqueakKara-Tests/SKKaraTest.class.st
+++ b/src/SqueakKara-Tests/SKKaraTest.class.st
@@ -27,7 +27,7 @@ SKKaraTest >> gridSize [
 
 {
 	#category : #setup,
-	#'squeak_changestamp' : 'jt 6/11/2024 11:14'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:20'
 }
 SKKaraTest >> setUp [
 

--- a/src/SqueakKara-Tests/SKLogicGraphTest.class.st
+++ b/src/SqueakKara-Tests/SKLogicGraphTest.class.st
@@ -1,0 +1,208 @@
+Class {
+	#name : #SKLogicGraphTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'runner',
+		'executeContext'
+	],
+	#category : #'SqueakKara-Tests'
+}
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:28'
+}
+SKLogicGraphTest >> executeContext [
+
+	^ executeContext
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:29'
+}
+SKLogicGraphTest >> executeContext: aExecuteContext [
+
+	executeContext := aExecuteContext
+]
+
+{
+	#category : #util,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:40'
+}
+SKLogicGraphTest >> executeSteps: aNumber [
+
+	(1 to: aNumber) do: [:i| self runner executeStep]
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:23'
+}
+SKLogicGraphTest >> runner [
+	
+	^ runner
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:24'
+}
+SKLogicGraphTest >> runner: aRunner [
+	
+	runner := aRunner
+]
+
+{
+	#category : #setup,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:33'
+}
+SKLogicGraphTest >> setUp [
+
+	self executeContext: (SKExecuteContext new).
+	self runner: (SKLogicRunner newWithExecutionContext: self executeContext)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:59'
+}
+SKLogicGraphTest >> testAccessToUndefinedVariables [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph 
+		addEdgeFrom: 'node1' to: 'node2' command: '' condition: 'env at: #non'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	
+	self executeSteps: 1.
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:47'
+}
+SKLogicGraphTest >> testBaseCondition [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: '(env at: #con) < 11'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	env at: #con put: 10.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:44'
+}
+SKLogicGraphTest >> testBasicEdgeExecution [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: 'true'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:53'
+}
+SKLogicGraphTest >> testDefaultEdge [
+
+	
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: ''.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:54'
+}
+SKLogicGraphTest >> testNoPossibleEdge [
+
+	
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph 
+		addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: 'false';
+		addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: '(env at: #con) < 10'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	env at: #con put: 10.
+	
+	self executeSteps: 4.
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 23:01'
+}
+SKLogicGraphTest >> testSelfLoop [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph addNodeWithName: 'node1'.
+	graph addEdgeFrom: 'node1' to: 'node1' command: 'env at: #test put: ((env at: #test) + 1)' condition: ''.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: 0.
+	
+	self executeSteps: 5.
+	
+	self assert: (env at: #test) = 5
+]

--- a/src/SqueakKara-Tests/package.st
+++ b/src/SqueakKara-Tests/package.st
@@ -1,4 +1,4 @@
 Package {
-	#name : #'SqueakKara-Tests',
-	#'squeak_changestamp' : true
+	#'squeak_changestamp' : true,
+	#name : #'SqueakKara-Tests'
 }

--- a/src/SqueakKara/SKContextVariables.class.st
+++ b/src/SqueakKara/SKContextVariables.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #SKContextVariables,
+	#superclass : #Dictionary,
+	#instVars : [
+		'dictionary'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:59'
+}
+SKContextVariables >> at: aKey [
+
+	(self dictionary includesKey: aKey) ifFalse: [
+			self dictionary at: aKey put: nil.
+			Transcript show: '[ContextVariables] Key not found'; cr].
+		
+	^ self dictionary at: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:44'
+}
+SKContextVariables >> at: aKey put: aValue [
+
+	self dictionary at: aKey put: aValue
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:41'
+}
+SKContextVariables >> dictionary [
+
+	^ dictionary ifNil: [dictionary := Dictionary new]
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:26'
+}
+SKContextVariables >> includes: aKey [
+
+	^ self dictionary includes: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:27'
+}
+SKContextVariables >> includesKey: aKey [
+
+	^ self dictionary includesKey: aKey
+]
+
+{
+	#category : #actions,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:41'
+}
+SKContextVariables >> reset [
+	
+	dictionary := nil 
+]

--- a/src/SqueakKara/SKEnvironment.class.st
+++ b/src/SqueakKara/SKEnvironment.class.st
@@ -12,7 +12,8 @@ Class {
 		'executeControls',
 		'gameWidth',
 		'gameHeight',
-		'systemWindow'
+		'systemWindow',
+		'logicGraph'
 	],
 	#category : #'SqueakKara-Core',
 	#'squeak_changestamp' : 'JJG 7/1/2024 15:38'

--- a/src/SqueakKara/SKExecuteContext.class.st
+++ b/src/SqueakKara/SKExecuteContext.class.st
@@ -7,11 +7,30 @@ Class {
 	#instVars : [
 		'kara',
 		'right',
-		'left'
+		'left',
+		'env'
 	],
 	#category : #'SqueakKara-Core',
 	#'squeak_changestamp' : 'JJG 7/1/2024 15:41'
 }
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:42'
+}
+SKExecuteContext >> env [
+
+	^ env
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:04'
+}
+SKExecuteContext >> env: aDictonary [
+
+	env := aDictonary
+]
 
 {
 	#category : #initialization,

--- a/src/SqueakKara/SKExecuteContext.class.st
+++ b/src/SqueakKara/SKExecuteContext.class.st
@@ -25,7 +25,7 @@ SKExecuteContext >> initialize [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'JJG 6/17/2024 16:40'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:05'
 }
 SKExecuteContext >> kara: anObject [
 	

--- a/src/SqueakKara/SKKaraTest.class.st
+++ b/src/SqueakKara/SKKaraTest.class.st
@@ -27,7 +27,7 @@ SKKaraTest >> gridSize [
 
 {
 	#category : #setup,
-	#'squeak_changestamp' : 'jt 6/11/2024 11:14'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:20'
 }
 SKKaraTest >> setUp [
 

--- a/src/SqueakKara/SKLogicEdge.class.st
+++ b/src/SqueakKara/SKLogicEdge.class.st
@@ -2,19 +2,61 @@ Class {
 	#name : #SKLogicEdge,
 	#superclass : #Object,
 	#instVars : [
-		'inNode',
-		'outNode',
+		'toNode',
+		'fromNode',
 		'command',
-		'condition'
+		'condition',
+		'hasDefaultCondition'
 	],
 	#category : #'SqueakKara-Core'
 }
 
 {
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:52'
+}
+SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: aLogicNode inNode: anotherLogicNode [
+
+	^(self new
+		command: aString;
+		condition: anotherString;
+		outNode: aLogicNode;
+		inNode: anotherLogicNode;
+		yourself)
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:43'
+}
+SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: anotherLogicNode [
+
+	^(self new
+		command: aString;
+		condition: anotherString;
+		toNode: anotherLogicNode;
+		yourself)
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:01'
+}
+SKLogicEdge class >> newWithOutNode: aLogicNode inNode: anotherLogicNode [
+
+	^ (self new
+		outNode: aLogicNode;
+		inNode: anotherLogicNode;
+		yourself)
+]
+
+{
 	#category : #visitor,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:25'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:37'
 }
 SKLogicEdge >> accept: aVisitor [
+
+	aVisitor visitLogicEdge: self
 ]
 
 {
@@ -37,54 +79,73 @@ SKLogicEdge >> command: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:27'
 }
 SKLogicEdge >> condition [
 
-	^ condition ifNil: [ condition := 'default' ]
+	^ condition ifNil: [ condition := '' ]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:30'
 }
 SKLogicEdge >> condition: aString [
 
+	self toggleHasNoDefaultCondition.
 	condition := aString
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> inNode [
+SKLogicEdge >> fromNode [
 
-	^ inNode
+	^ fromNode
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> inNode: aLogicNode [
+SKLogicEdge >> fromNode: aLogicNode [
 
-	inNode := aLogicNode
+	fromNode := aLogicNode
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:46'
 }
-SKLogicEdge >> outNode [
-
-	^ outNode
+SKLogicEdge >> hasDefaultCondition [
+	
+	^ hasDefaultCondition ifNil: [hasDefaultCondition := true]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:44'
 }
-SKLogicEdge >> outNode: aLogicNode [
+SKLogicEdge >> toNode [
 
-	outNode := aLogicNode
+	^ toNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:45'
+}
+SKLogicEdge >> toNode: aLogicNode [
+
+	toNode := aLogicNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:29'
+}
+SKLogicEdge >> toggleHasNoDefaultCondition [
+
+	hasDefaultCondition := false
 ]

--- a/src/SqueakKara/SKLogicEdge.class.st
+++ b/src/SqueakKara/SKLogicEdge.class.st
@@ -13,9 +13,9 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:52'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:19'
 }
-SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: aLogicNode inNode: anotherLogicNode [
+SKLogicEdge class >> newWithCommand: aString condition: anotherString fromNode: aLogicNode toNode: anotherLogicNode [
 
 	^(self new
 		command: aString;
@@ -27,36 +27,27 @@ SKLogicEdge class >> newWithCommand: aString condition: anotherString outNode: a
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:43'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:30'
 }
-SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: anotherLogicNode [
+SKLogicEdge class >> newWithCommand: aString condition: anotherString toNode: aLogicNode [
 
 	^(self new
 		command: aString;
 		condition: anotherString;
-		toNode: anotherLogicNode;
+		toNode: aLogicNode;
 		yourself)
 ]
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:01'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:19'
 }
-SKLogicEdge class >> newWithOutNode: aLogicNode inNode: anotherLogicNode [
+SKLogicEdge class >> newWithfromNode: aLogicNode toNode: anotherLogicNode [
 
 	^ (self new
 		outNode: aLogicNode;
 		inNode: anotherLogicNode;
 		yourself)
-]
-
-{
-	#category : #visitor,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:37'
-}
-SKLogicEdge >> accept: aVisitor [
-
-	aVisitor visitLogicEdge: self
 ]
 
 {
@@ -88,11 +79,11 @@ SKLogicEdge >> condition [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:30'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:50'
 }
 SKLogicEdge >> condition: aString [
 
-	self toggleHasNoDefaultCondition.
+	(aString  ~= '') ifTrue: [self toggleHasNoDefaultCondition].
 	condition := aString
 ]
 

--- a/src/SqueakKara/SKLogicEdge.class.st
+++ b/src/SqueakKara/SKLogicEdge.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : #SKLogicEdge,
+	#superclass : #Object,
+	#instVars : [
+		'inNode',
+		'outNode',
+		'command',
+		'condition'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #visitor,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:25'
+}
+SKLogicEdge >> accept: aVisitor [
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:24'
+}
+SKLogicEdge >> command [
+
+	^ command ifNil: [ command := '' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:22'
+}
+SKLogicEdge >> command: aString [
+
+	command := aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+}
+SKLogicEdge >> condition [
+
+	^ condition ifNil: [ condition := 'default' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:23'
+}
+SKLogicEdge >> condition: aString [
+
+	condition := aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> inNode [
+
+	^ inNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> inNode: aLogicNode [
+
+	inNode := aLogicNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> outNode [
+
+	^ outNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:21'
+}
+SKLogicEdge >> outNode: aLogicNode [
+
+	outNode := aLogicNode
+]

--- a/src/SqueakKara/SKLogicGraph.class.st
+++ b/src/SqueakKara/SKLogicGraph.class.st
@@ -8,6 +8,17 @@ Class {
 }
 
 {
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:54'
+}
+SKLogicGraph class >> newWithStartingNode: aLogicNode [
+	
+	^ (self new
+		startingNode: aLogicNode;
+		yourself)
+]
+
+{
 	#category : #accessing,
 	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
 }

--- a/src/SqueakKara/SKLogicGraph.class.st
+++ b/src/SqueakKara/SKLogicGraph.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : #SKLogicGraph,
 	#superclass : #Object,
 	#instVars : [
-		'startingNode'
+		'startingNode',
+		'nodes',
+		'edges'
 	],
 	#category : #'SqueakKara-Core'
 }
@@ -16,6 +18,86 @@ SKLogicGraph class >> newWithStartingNode: aLogicNode [
 	^ (self new
 		startingNode: aLogicNode;
 		yourself)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:09'
+}
+SKLogicGraph >> addEdge: aLogicEdge [
+
+	self edges at: (aLogicEdge toNode name) put: aLogicEdge
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:18'
+}
+SKLogicGraph >> addEdgeFrom: aFromString to: aToString command: aCommandString condition: aConditionString [
+
+	 | fromNode toNode edge|
+	
+	fromNode := self getNodeByName: aFromString.
+	toNode := self getNodeByName: aToString.
+	edge := fromNode addEdge: (SKLogicEdge newWithCommand: aCommandString condition: aConditionString toNode: toNode).
+	self addEdge: edge	
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:09'
+}
+SKLogicGraph >> addNode: aLogicNode [
+
+	self nodes at: (aLogicNode name) put: aLogicNode
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:04'
+}
+SKLogicGraph >> addNodeWithName: aString [
+
+	self addNode: (SKLogicNode newWithName: aString)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:11'
+}
+SKLogicGraph >> edges [
+
+	^ edges ifNil: [edges := Dictionary new]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:25'
+}
+SKLogicGraph >> getNodeByName: aString [ 
+
+	(self nodes includesKey: aString) ifFalse: [
+		self error:  '[LogicGraph] No node found with name: ' , aString.
+		^ nil].
+	^ self nodes at: aString
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:08'
+}
+SKLogicGraph >> nodes [
+
+	^ nodes ifNil: [nodes := Dictionary new]
+]
+
+{
+	#category : #construction,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:31'
+}
+SKLogicGraph >> setStartNode: aString [
+
+	self startingNode: (self getNodeByName: aString)
 ]
 
 {

--- a/src/SqueakKara/SKLogicGraph.class.st
+++ b/src/SqueakKara/SKLogicGraph.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #SKLogicGraph,
+	#superclass : #Object,
+	#instVars : [
+		'startingNode'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
+}
+SKLogicGraph >> startingNode [
+
+	^ startingNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:29'
+}
+SKLogicGraph >> startingNode: aLogicNode [
+
+	startingNode := aLogicNode
+]

--- a/src/SqueakKara/SKLogicGraphTest.class.st
+++ b/src/SqueakKara/SKLogicGraphTest.class.st
@@ -1,0 +1,208 @@
+Class {
+	#name : #SKLogicGraphTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'runner',
+		'executeContext'
+	],
+	#category : #'SqueakKara-Tests'
+}
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:28'
+}
+SKLogicGraphTest >> executeContext [
+
+	^ executeContext
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:29'
+}
+SKLogicGraphTest >> executeContext: aExecuteContext [
+
+	executeContext := aExecuteContext
+]
+
+{
+	#category : #util,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:40'
+}
+SKLogicGraphTest >> executeSteps: aNumber [
+
+	(1 to: aNumber) do: [:i| self runner executeStep]
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:23'
+}
+SKLogicGraphTest >> runner [
+	
+	^ runner
+]
+
+{
+	#category : #asseccing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:24'
+}
+SKLogicGraphTest >> runner: aRunner [
+	
+	runner := aRunner
+]
+
+{
+	#category : #setup,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:33'
+}
+SKLogicGraphTest >> setUp [
+
+	self executeContext: (SKExecuteContext new).
+	self runner: (SKLogicRunner newWithExecutionContext: self executeContext)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:59'
+}
+SKLogicGraphTest >> testAccessToUndefinedVariables [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph 
+		addEdgeFrom: 'node1' to: 'node2' command: '' condition: 'env at: #non'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	
+	self executeSteps: 1.
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:47'
+}
+SKLogicGraphTest >> testBaseCondition [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: '(env at: #con) < 11'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	env at: #con put: 10.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:44'
+}
+SKLogicGraphTest >> testBasicEdgeExecution [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: 'true'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:53'
+}
+SKLogicGraphTest >> testDefaultEdge [
+
+	
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: ''.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	
+	self executeSteps: 1.
+	
+	self assert: (env at: #test)
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:54'
+}
+SKLogicGraphTest >> testNoPossibleEdge [
+
+	
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph
+		addNodeWithName: 'node1';
+		addNodeWithName: 'node2'.
+	graph 
+		addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: 'false';
+		addEdgeFrom: 'node1' to: 'node2' command: 'env at: #test put: true' condition: '(env at: #con) < 10'.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: false.
+	env at: #con put: 10.
+	
+	self executeSteps: 4.
+]
+
+{
+	#category : #testing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 23:01'
+}
+SKLogicGraphTest >> testSelfLoop [
+
+	| graph env|
+	
+	graph := SKLogicGraph new.
+	graph addNodeWithName: 'node1'.
+	graph addEdgeFrom: 'node1' to: 'node1' command: 'env at: #test put: ((env at: #test) + 1)' condition: ''.
+	graph setStartNode: 'node1'.
+	
+	self runner attachToGraph: graph.
+	env := self runner executeContext env.
+	env at: #test put: 0.
+	
+	self executeSteps: 5.
+	
+	self assert: (env at: #test) = 5
+]

--- a/src/SqueakKara/SKLogicNode.class.st
+++ b/src/SqueakKara/SKLogicNode.class.st
@@ -9,21 +9,42 @@ Class {
 }
 
 {
-	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:18'
+	#category : #constructor,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:49'
 }
-SKLogicNode >> addEdge: aLogicEdge [
+SKLogicNode class >> newWithName: aString [
 	
-	edges add: aLogicEdge 
+	^ (self new
+		name: aString;
+		yourself)
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:47'
+}
+SKLogicNode >> addEdge: aLogicEdge [
+	
+	aLogicEdge fromNode: self.
+	self edges add: aLogicEdge 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:04'
 }
 SKLogicNode >> edges [
 
-	^ edges
+	^ edges ifNil: [edges := OrderedCollection new]
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:05'
+}
+SKLogicNode >> hasEdge [
+
+	^ (self edges size > 0)
 ]
 
 {

--- a/src/SqueakKara/SKLogicNode.class.st
+++ b/src/SqueakKara/SKLogicNode.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #SKLogicNode,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'edges'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:18'
+}
+SKLogicNode >> addEdge: aLogicEdge [
+	
+	edges add: aLogicEdge 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+}
+SKLogicNode >> edges [
+
+	^ edges
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:15'
+}
+SKLogicNode >> name [
+
+	^ name ifNil: [ name := '' ]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:14'
+}
+SKLogicNode >> name: aString [
+	
+	name := aString
+]

--- a/src/SqueakKara/SKLogicNode.class.st
+++ b/src/SqueakKara/SKLogicNode.class.st
@@ -21,12 +21,14 @@ SKLogicNode class >> newWithName: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:47'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:06'
 }
 SKLogicNode >> addEdge: aLogicEdge [
 	
 	aLogicEdge fromNode: self.
-	self edges add: aLogicEdge 
+	self edges add: aLogicEdge.
+	
+	^ aLogicEdge
 ]
 
 {

--- a/src/SqueakKara/SKLogicRunner.class.st
+++ b/src/SqueakKara/SKLogicRunner.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #SKLogicRunner,
+	#superclass : #Object,
+	#instVars : [
+		'currentNode'
+	],
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:32'
+}
+SKLogicRunner >> currentNode [
+	
+	^ currentNode
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:32'
+}
+SKLogicRunner >> currentNode: aLogicNode [
+
+	currentNode := aLogicNode
+]

--- a/src/SqueakKara/SKLogicRunner.class.st
+++ b/src/SqueakKara/SKLogicRunner.class.st
@@ -11,25 +11,24 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:03'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:07'
 }
-SKLogicRunner class >> newWithKara: aKara [
+SKLogicRunner class >> newWithExecutionContext: aExecutionContext [
 
-	| runner |
-	
-	runner := self new.
-	runner executeContext kara: aKara.
-	^ runner
+	^ (self new
+		executeContext: aExecutionContext copy;
+		yourself)
 ]
 
 {
 	#category : #initialize,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 21:45'
 }
 SKLogicRunner >> attachToGraph: aLogicGraph [
 
 	Transcript show: '[LogicRunner] Attacht to startingNode: ' , aLogicGraph startingNode name; cr.
 
+	self executeContext env: (SKContextVariables new).
 	self compiler: (Compiler new);
 		currentNode: aLogicGraph startingNode 
 ]
@@ -81,11 +80,11 @@ SKLogicRunner >> executeCode: aString [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:32'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 20:56'
 }
 SKLogicRunner >> executeContext [
 
-	^ executeContext ifNil: [executeContext := SKExecuteContext new]
+	^ executeContext
 ]
 
 {
@@ -99,7 +98,7 @@ SKLogicRunner >> executeContext: aExecuteContext [
 
 {
 	#category : #execution,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:07'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:55'
 }
 SKLogicRunner >> executeStep [
 	
@@ -117,7 +116,7 @@ SKLogicRunner >> executeStep [
 
 {
 	#category : #execution,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:14'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:55'
 }
 SKLogicRunner >> findNextEdge: aLogicNode [
 
@@ -145,13 +144,4 @@ SKLogicRunner >> traverseEdge: aLogicEdge [
 
 	self currentNode: aLogicEdge toNode
 	
-]
-
-{
-	#category : #visit,
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:39'
-}
-SKLogicRunner >> visitLogicEdge: aLogicEdge [
-
-	self traverseEdge: aLogicEdge
 ]

--- a/src/SqueakKara/SKLogicRunner.class.st
+++ b/src/SqueakKara/SKLogicRunner.class.st
@@ -2,10 +2,55 @@ Class {
 	#name : #SKLogicRunner,
 	#superclass : #Object,
 	#instVars : [
-		'currentNode'
+		'currentNode',
+		'executeContext',
+		'compiler'
 	],
 	#category : #'SqueakKara-Core'
 }
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:03'
+}
+SKLogicRunner class >> newWithKara: aKara [
+
+	| runner |
+	
+	runner := self new.
+	runner executeContext kara: aKara.
+	^ runner
+]
+
+{
+	#category : #initialize,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+}
+SKLogicRunner >> attachToGraph: aLogicGraph [
+
+	Transcript show: '[LogicRunner] Attacht to startingNode: ' , aLogicGraph startingNode name; cr.
+
+	self compiler: (Compiler new);
+		currentNode: aLogicGraph startingNode 
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:36'
+}
+SKLogicRunner >> compiler [
+
+	^ compiler
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:36'
+}
+SKLogicRunner >> compiler: aCompiler [
+
+	compiler := aCompiler
+]
 
 {
 	#category : #accessing,
@@ -23,4 +68,90 @@ SKLogicRunner >> currentNode [
 SKLogicRunner >> currentNode: aLogicNode [
 
 	currentNode := aLogicNode
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:40'
+}
+SKLogicRunner >> executeCode: aString [
+
+	^ (self compiler evaluate: aString for: self executeContext)
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:32'
+}
+SKLogicRunner >> executeContext [
+
+	^ executeContext ifNil: [executeContext := SKExecuteContext new]
+]
+
+{
+	#category : #accessing,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 15:21'
+}
+SKLogicRunner >> executeContext: aExecuteContext [
+	
+	^ executeContext := aExecuteContext
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:07'
+}
+SKLogicRunner >> executeStep [
+	
+	| nextEdge |
+	
+	self currentNode hasEdge ifFalse: [
+			Transcript show: '[LoigcRunner] ', currentNode name , ' has no edges'; cr.
+			^ nil].
+	nextEdge := self findNextEdge: self currentNode. 
+	nextEdge ifNil: [^ nil].
+	
+	self	executeCode: nextEdge command; 
+		traverseEdge: nextEdge
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:14'
+}
+SKLogicRunner >> findNextEdge: aLogicNode [
+
+	| possibleEdges defaultEdges result |
+	
+	possibleEdges := aLogicNode edges select: [:aEdge |
+			result := self executeCode: aEdge condition.
+			((aEdge hasDefaultCondition not) and: (result isBoolean)) and: result].
+	defaultEdges := aLogicNode edges select: [:aEdge | aEdge hasDefaultCondition].
+	
+	(possibleEdges size > 0) ifTrue: [^ possibleEdges first].
+	(defaultEdges size > 0) ifTrue: [^ defaultEdges first].
+	
+	Transcript show: '[LogicRunner] No possible edge found'; cr.
+	^ nil
+]
+
+{
+	#category : #execution,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 16:45'
+}
+SKLogicRunner >> traverseEdge: aLogicEdge [
+
+	Transcript show: ('[LogicRunner] ' , aLogicEdge fromNode name, ' --> ', aLogicEdge toNode name); cr.
+
+	self currentNode: aLogicEdge toNode
+	
+]
+
+{
+	#category : #visit,
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 14:39'
+}
+SKLogicRunner >> visitLogicEdge: aLogicEdge [
+
+	self traverseEdge: aLogicEdge
 ]

--- a/src/SqueakKara/SKTestGround.class.st
+++ b/src/SqueakKara/SKTestGround.class.st
@@ -6,22 +6,26 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 22:31'
 }
 SKTestGround >> testLogicGraphWithKara [
 
-	| node1 node2 edge12 graph runner grid kara | 
+	| graph runner grid kara executionContext | 
 	
-	node1 := SKLogicNode newWithName: 'node1'.
-	node2 := SKLogicNode newWithName: 'node2'.
-	edge12 := SKLogicEdge newWithCommand: 'kara move' condition: 'true' toNode: node2.
-	node1 addEdge: edge12.
-	graph := SKLogicGraph newWithStartingNode: node1.
+	graph := (SKLogicGraph new
+				addNodeWithName: 'node1';
+				addNodeWithName: 'node2';
+				addEdgeFrom: 'node1' to: 'node2' command: 'kara move. env at: #test put: true' condition: 'true';
+				addEdgeFrom: 'node2' to: 'node1' command: '' condition: 'env at: #test';
+				setStartNode: 'node1';
+				yourself).
 	
 	grid := SKGrid newWithExtent: 7@7.
 	kara := SKKara newInGrid: grid at: 1@1.
+	executionContext := SKExecuteContext new.
+	executionContext kara: kara.
 
-	runner := SKLogicRunner newWithKara: kara.
+	runner := SKLogicRunner newWithExecutionContext: executionContext.
 	runner attachToGraph: graph.
 
 	^ runner

--- a/src/SqueakKara/SKTestGround.class.st
+++ b/src/SqueakKara/SKTestGround.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #SKTestGround,
+	#superclass : #Object,
+	#category : #'SqueakKara-Core'
+}
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Lars Kuhr 5/5/2026 17:06'
+}
+SKTestGround >> testLogicGraphWithKara [
+
+	| node1 node2 edge12 graph runner grid kara | 
+	
+	node1 := SKLogicNode newWithName: 'node1'.
+	node2 := SKLogicNode newWithName: 'node2'.
+	edge12 := SKLogicEdge newWithCommand: 'kara move' condition: 'true' toNode: node2.
+	node1 addEdge: edge12.
+	graph := SKLogicGraph newWithStartingNode: node1.
+	
+	grid := SKGrid newWithExtent: 7@7.
+	kara := SKKara newInGrid: grid at: 1@1.
+
+	runner := SKLogicRunner newWithKara: kara.
+	runner attachToGraph: graph.
+
+	^ runner
+]

--- a/src/SqueakKara/package.st
+++ b/src/SqueakKara/package.st
@@ -1,4 +1,4 @@
 Package {
-	#name : #SqueakKara,
-	#'squeak_changestamp' : true
+	#'squeak_changestamp' : true,
+	#name : #SqueakKara
 }


### PR DESCRIPTION
## Summary

I added the core structure for the state machine, consisting of nodes and edges organized as a graph. In addition, I introduced a `LogicGraphRunner` that can be attached to a graph and executes it step by step.

## Changes

- Added a `LogicNode` class that stores its name and all outgoing edges.
- Added a `LogicEdge` class that defines a condition under which it is executed and a command to run. If no condition is provided, the edge is treated as the default edge.
- Added a `LogicGraph` class that stores all nodes and edges, defines the starting node, and provides builder functions for constructing the graph.
- Added a `LogicGraphRunner` that can be attached to a graph and execute it step by step using the `executeStep` function. It evaluates all outgoing edges of the current node, executes the first edge whose condition evaluates to `true`, and falls back to the first default edge if no condition matches.
- Added a `contextVariables` object that stores all variables for a single execution. It uses a `Dictionary` with custom guards to prevent Squeak errors when accessing undefined keys.