### PR TITLE
Implemented an Error message that appears for 3 seconds inside a speech bubble

### DIFF
--- a/src/SqueakKara/SKKara.class.st
+++ b/src/SqueakKara/SKKara.class.st
@@ -206,12 +206,16 @@ SKKara >> lockNextField [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'mr 6/5/2026 12:16'
+	#'squeak_changestamp' : 'LD 6/9/2026 19:17'
 }
 SKKara >> move [
-
-	(self trunkAhead) ifTrue: [ ^ false ].
-	^ (self moveToCoordinates: self coordinates + self viewDirection)
+	
+	self stopSayingOrThinking.
+	(self trunkAhead) ifTrue: [ self sayMessageForSomeTime: 'Aua! Ich bin gegen einen Baumstumpf gelaufen D:'.
+		^ false ].
+	(self moveToCoordinates: self coordinates + self viewDirection) ifTrue: [
+		^ true ]
+		ifFalse: [self sayMessageForSomeTime: 'Aua! Da darf ich nicht hinlaufen D:' ]
 ]
 
 {
@@ -291,6 +295,18 @@ SKKara >> rotate [
 	}.
 	
 	^ image
+]
+
+{
+	#category : #movement,
+	#'squeak_changestamp' : 'LD 6/9/2026 19:22'
+}
+SKKara >> sayMessageForSomeTime: aString [
+	| delayTime |
+	delayTime := 3.
+	self say: aString.
+	(Delay forSeconds: delayTime) wait.
+	self stopSayingOrThinking.
 ]
 
 {

--- a/src/SqueakKara/SKKara.class.st
+++ b/src/SqueakKara/SKKara.class.st
@@ -299,11 +299,12 @@ SKKara >> rotate [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'LD 6/9/2026 21:19'
+	#'squeak_changestamp' : 'LD 6/9/2026 21:24'
 }
 SKKara >> sayMessageForSomeTime: aString [
 	
 	| delayTime |
+	
 	delayTime := 3.
 	self say: aString.
 	(Delay forSeconds: delayTime) wait.

--- a/src/SqueakKara/SKKara.class.st
+++ b/src/SqueakKara/SKKara.class.st
@@ -206,16 +206,19 @@ SKKara >> lockNextField [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'LD 6/10/2026 14:49'
+	#'squeak_changestamp' : 'LD 6/10/2026 15:57'
 }
 SKKara >> move [
 	
 	self stopSayingOrThinking.
-	(self trunkAhead) ifTrue: [ self sayMessageForThreeSeconds: 'Aua! Ich bin gegen einen Baumstumpf gelaufen D:'.
+	(self trunkAhead) ifTrue: [ 
+		self sayMessageForThreeSeconds: 'Aua! Ich bin gegen einen Baumstumpf gelaufen D:'.
 		^ false ].
 	(self moveToCoordinates: self coordinates + self viewDirection) ifTrue: [
 		^ true ]
-		ifFalse: [self sayMessageForThreeSeconds: 'Aua! Da darf ich nicht hinlaufen D:' ]
+		ifFalse: [ 
+			self sayMessageForThreeSeconds: 'Aua! Da darf ich nicht hinlaufen D:'.
+			^ false ]
 ]
 
 {

--- a/src/SqueakKara/SKKara.class.st
+++ b/src/SqueakKara/SKKara.class.st
@@ -206,16 +206,16 @@ SKKara >> lockNextField [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'LD 6/9/2026 19:17'
+	#'squeak_changestamp' : 'LD 6/10/2026 14:49'
 }
 SKKara >> move [
 	
 	self stopSayingOrThinking.
-	(self trunkAhead) ifTrue: [ self sayMessageForSomeTime: 'Aua! Ich bin gegen einen Baumstumpf gelaufen D:'.
+	(self trunkAhead) ifTrue: [ self sayMessageForThreeSeconds: 'Aua! Ich bin gegen einen Baumstumpf gelaufen D:'.
 		^ false ].
 	(self moveToCoordinates: self coordinates + self viewDirection) ifTrue: [
 		^ true ]
-		ifFalse: [self sayMessageForSomeTime: 'Aua! Da darf ich nicht hinlaufen D:' ]
+		ifFalse: [self sayMessageForThreeSeconds: 'Aua! Da darf ich nicht hinlaufen D:' ]
 ]
 
 {
@@ -299,9 +299,9 @@ SKKara >> rotate [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'LD 6/9/2026 21:24'
+	#'squeak_changestamp' : 'LD 6/10/2026 14:49'
 }
-SKKara >> sayMessageForSomeTime: aString [
+SKKara >> sayMessageForThreeSeconds: aString [
 	
 	| delayTime |
 	

--- a/src/SqueakKara/SKKara.class.st
+++ b/src/SqueakKara/SKKara.class.st
@@ -299,14 +299,15 @@ SKKara >> rotate [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'LD 6/9/2026 19:22'
+	#'squeak_changestamp' : 'LD 6/9/2026 21:19'
 }
 SKKara >> sayMessageForSomeTime: aString [
+	
 	| delayTime |
 	delayTime := 3.
 	self say: aString.
 	(Delay forSeconds: delayTime) wait.
-	self stopSayingOrThinking.
+	self stopSayingOrThinking
 ]
 
 {

--- a/src/SqueakKara/SKKaraProxy.class.st
+++ b/src/SqueakKara/SKKaraProxy.class.st
@@ -110,7 +110,7 @@ SKKaraProxy >> move [
 
 {
 	#category : #commands,
-	#'squeak_changestamp' : 'LM 5/28/2026 19:36'
+	#'squeak_changestamp' : 'LD 6/9/2026 19:16'
 }
 SKKaraProxy >> moveAction [
 
@@ -119,7 +119,9 @@ SKKaraProxy >> moveAction [
 			| previousPosition |
 			previousPosition := self coordinates.
 			self kara move ]
-		ifTrue: [ false ]
+		ifTrue: [ 
+			self kara sayMessageForSomeTime: 'Hey, auf dem Feld ist bereits eine Kara!'.
+			false ]
 ]
 
 {

--- a/src/SqueakKara/SKKaraProxy.class.st
+++ b/src/SqueakKara/SKKaraProxy.class.st
@@ -110,7 +110,7 @@ SKKaraProxy >> move [
 
 {
 	#category : #commands,
-	#'squeak_changestamp' : 'LD 6/9/2026 19:16'
+	#'squeak_changestamp' : 'LD 6/10/2026 14:49'
 }
 SKKaraProxy >> moveAction [
 
@@ -120,7 +120,7 @@ SKKaraProxy >> moveAction [
 			previousPosition := self coordinates.
 			self kara move ]
 		ifTrue: [ 
-			self kara sayMessageForSomeTime: 'Hey, auf dem Feld ist bereits eine Kara!'.
+			self kara sayMessageForThreeSeconds: 'Hey, auf dem Feld ist bereits eine Kara!'.
 			false ]
 ]
 


### PR DESCRIPTION
Whenever a kara wants to move but can't (when a trunk or another kara is on the field that kara wants to move to, or kara trys to move outside the playing-field) an error-Speechbubble is shown.

New method: `sayMessageForSomeTime: aString` spawns a bubble that lasts for 3 seconds