### PR TITLE
Swt26 g08/199 moveable start node

### DIFF
--- a/src/SqueakKara-Core/SKMealyNode.class.st
+++ b/src/SqueakKara-Core/SKMealyNode.class.st
@@ -253,15 +253,14 @@ SKMealyNode >> isStartingNode: aBoolean [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:47'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:56'
 }
 SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
-	"(newOwner isKindOf: SKPlayGround) ifFalse: [anEvent hand attachMorph: self. ^self]."
-
 	newOwner addMorphFront: self.
 	self isInDrag: false;
-		triggerSelfLoopUpdate
+		triggerSelfLoopUpdate;
+		positionInPlayground: newOwner
 ]
 
 {
@@ -323,6 +322,28 @@ SKMealyNode >> newAngle: aAngle [
 SKMealyNode >> normalColor [
 
 	^ SKStylesheet colorOrange
+]
+
+{
+	#category : #movement,
+	#'squeak_changestamp' : 'JS 6/23/2026 23:56'
+}
+SKMealyNode >> positionInPlayground: aPlayground [
+
+    | posX posY |
+
+    	posX := self position x.
+	posY := self position y.
+
+    	posX := posX max: aPlayground bounds left.
+
+   	posX := posX min: aPlayground bounds right - self width.
+
+    	posY := posY max: aPlayground bounds top.
+
+    	posY := posY min: aPlayground bounds bottom - self height.
+
+    	self position: posX @ posY.
 ]
 
 {
@@ -433,7 +454,7 @@ SKMealyNode >> updateSelfLoops [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:48'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:46'
 }
 SKMealyNode >> wantsToBeDroppedInto: aMorph [
 

--- a/src/SqueakKara-Core/SKMealyNode.class.st
+++ b/src/SqueakKara-Core/SKMealyNode.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'controller',
 		'isInDrag',
-		'isDraggable',
 		'stateMachineEditor',
 		'isStartingNode',
 		'name',
@@ -204,7 +203,7 @@ SKMealyNode >> handlesMouseDown: anEvent [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'JS 6/16/2026 19:25'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:08'
 }
 SKMealyNode >> initialize [
 
@@ -213,26 +212,7 @@ SKMealyNode >> initialize [
 	self extent: self defaultSize;
 		color: self normalColor;
 		borderWidth: 3;
-		isStartingNode: false;
-		isDraggable: true
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:47'
-}
-SKMealyNode >> isDraggable [
-
-	^ isDraggable
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:47'
-}
-SKMealyNode >> isDraggable: anObject [
-
-	isDraggable := anObject
+		isStartingNode: false
 ]
 
 {
@@ -273,12 +253,11 @@ SKMealyNode >> isStartingNode: aBoolean [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'Lars Kuhr 6/21/2026 15:31'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:47'
 }
 SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
-	(newOwner isKindOf: SKPlayGround) ifFalse: [controller queueNodeToDelete: self.
-		^ self].
+	"(newOwner isKindOf: SKPlayGround) ifFalse: [anEvent hand attachMorph: self. ^self]."
 
 	newOwner addMorphFront: self.
 	self isInDrag: false;
@@ -287,17 +266,16 @@ SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/16/2026 19:27'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:09'
 }
 SKMealyNode >> mouseDown: anEvent [
 
 	self controller mode = #drag ifTrue: [
-		self isDraggable ifTrue:[
 		anEvent hand
 		waitForClicksOrDrag: self
 		event: anEvent
 		selectors: {nil. nil. nil. #startDrag:}
-		threshold: HandMorph dragThreshold]].
+		threshold: HandMorph dragThreshold].
 	self controller nodeClicked: self
 
 ]
@@ -451,4 +429,13 @@ SKMealyNode >> updateSelfLoops [
 
 	self calculateBestEdgeDirections;
 		changed: #pos
+]
+
+{
+	#category : #movement,
+	#'squeak_changestamp' : 'JS 6/23/2026 22:48'
+}
+SKMealyNode >> wantsToBeDroppedInto: aMorph [
+
+	^ aMorph isKindOf: SKPlayGround
 ]

--- a/src/SqueakKara-Core/SKPlayGround.class.st
+++ b/src/SqueakKara-Core/SKPlayGround.class.st
@@ -11,7 +11,7 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/20/2026 09:44'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:59'
 }
 SKPlayGround class >> newWithController: aController [
 

--- a/src/SqueakKara-Core/SKSelectionModel.class.st
+++ b/src/SqueakKara-Core/SKSelectionModel.class.st
@@ -52,16 +52,16 @@ SKSelectionModel >> items: aItemCollection [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 6/23/2026 16:16'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedIndex [
 
-	^ selectedIndex ifNil: [^ 1]
+	^ selectedIndex ifNil: [selectedIndex := 0]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 6/23/2026 16:03'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedIndex: aNumber [
 
@@ -70,11 +70,11 @@ SKSelectionModel >> selectedIndex: aNumber [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'JS 6/23/2026 21:31'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedValue [
 
-	self selectedIndex ifNil: [^''].
+	self selectedIndex = 0 ifTrue: [^''].
 	^ self items at: self selectedIndex
 ]
 

--- a/src/SqueakKara-Core/SKStateMachineEditor.class.st
+++ b/src/SqueakKara-Core/SKStateMachineEditor.class.st
@@ -345,7 +345,7 @@ SKStateMachineEditor >> initializeModeButtons [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:07'
+	#'squeak_changestamp' : 'JS 6/24/2026 00:03'
 }
 SKStateMachineEditor >> initializePlayground [
 

--- a/src/SqueakKara-Core/SKStateMachineEditor.class.st
+++ b/src/SqueakKara-Core/SKStateMachineEditor.class.st
@@ -345,7 +345,7 @@ SKStateMachineEditor >> initializeModeButtons [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:48'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:07'
 }
 SKStateMachineEditor >> initializePlayground [
 
@@ -359,7 +359,7 @@ SKStateMachineEditor >> initializePlayground [
 	
 	startingNode := SKMealyNode newWithName: self nodeCounter asString.
 	self nodeCounterPP.
-	startingNode isStartingNode: true; isDraggable: false.
+	startingNode isStartingNode: true.
 	startingNode addMorph: (StringMorph new
 		contents: 'START';
 		color: Color black;

--- a/src/SqueakKara/SKMealyNode.class.st
+++ b/src/SqueakKara/SKMealyNode.class.st
@@ -253,15 +253,14 @@ SKMealyNode >> isStartingNode: aBoolean [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:47'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:56'
 }
 SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
-	"(newOwner isKindOf: SKPlayGround) ifFalse: [anEvent hand attachMorph: self. ^self]."
-
 	newOwner addMorphFront: self.
 	self isInDrag: false;
-		triggerSelfLoopUpdate
+		triggerSelfLoopUpdate;
+		positionInPlayground: newOwner
 ]
 
 {
@@ -323,6 +322,28 @@ SKMealyNode >> newAngle: aAngle [
 SKMealyNode >> normalColor [
 
 	^ SKStylesheet colorOrange
+]
+
+{
+	#category : #movement,
+	#'squeak_changestamp' : 'JS 6/23/2026 23:56'
+}
+SKMealyNode >> positionInPlayground: aPlayground [
+
+    | posX posY |
+
+    	posX := self position x.
+	posY := self position y.
+
+    	posX := posX max: aPlayground bounds left.
+
+   	posX := posX min: aPlayground bounds right - self width.
+
+    	posY := posY max: aPlayground bounds top.
+
+    	posY := posY min: aPlayground bounds bottom - self height.
+
+    	self position: posX @ posY.
 ]
 
 {
@@ -433,7 +454,7 @@ SKMealyNode >> updateSelfLoops [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:48'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:46'
 }
 SKMealyNode >> wantsToBeDroppedInto: aMorph [
 

--- a/src/SqueakKara/SKMealyNode.class.st
+++ b/src/SqueakKara/SKMealyNode.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'controller',
 		'isInDrag',
-		'isDraggable',
 		'stateMachineEditor',
 		'isStartingNode',
 		'name',
@@ -204,7 +203,7 @@ SKMealyNode >> handlesMouseDown: anEvent [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'JS 6/16/2026 19:25'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:08'
 }
 SKMealyNode >> initialize [
 
@@ -213,26 +212,7 @@ SKMealyNode >> initialize [
 	self extent: self defaultSize;
 		color: self normalColor;
 		borderWidth: 3;
-		isStartingNode: false;
-		isDraggable: true
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:47'
-}
-SKMealyNode >> isDraggable [
-
-	^ isDraggable
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:47'
-}
-SKMealyNode >> isDraggable: anObject [
-
-	isDraggable := anObject
+		isStartingNode: false
 ]
 
 {
@@ -273,12 +253,11 @@ SKMealyNode >> isStartingNode: aBoolean [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'Lars Kuhr 6/21/2026 15:31'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:47'
 }
 SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
-	(newOwner isKindOf: SKPlayGround) ifFalse: [controller queueNodeToDelete: self.
-		^ self].
+	"(newOwner isKindOf: SKPlayGround) ifFalse: [anEvent hand attachMorph: self. ^self]."
 
 	newOwner addMorphFront: self.
 	self isInDrag: false;
@@ -287,17 +266,16 @@ SKMealyNode >> justDroppedInto: newOwner event: anEvent [
 
 {
 	#category : #movement,
-	#'squeak_changestamp' : 'JS 6/16/2026 19:27'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:09'
 }
 SKMealyNode >> mouseDown: anEvent [
 
 	self controller mode = #drag ifTrue: [
-		self isDraggable ifTrue:[
 		anEvent hand
 		waitForClicksOrDrag: self
 		event: anEvent
 		selectors: {nil. nil. nil. #startDrag:}
-		threshold: HandMorph dragThreshold]].
+		threshold: HandMorph dragThreshold].
 	self controller nodeClicked: self
 
 ]
@@ -451,4 +429,13 @@ SKMealyNode >> updateSelfLoops [
 
 	self calculateBestEdgeDirections;
 		changed: #pos
+]
+
+{
+	#category : #movement,
+	#'squeak_changestamp' : 'JS 6/23/2026 22:48'
+}
+SKMealyNode >> wantsToBeDroppedInto: aMorph [
+
+	^ aMorph isKindOf: SKPlayGround
 ]

--- a/src/SqueakKara/SKPlayGround.class.st
+++ b/src/SqueakKara/SKPlayGround.class.st
@@ -11,7 +11,7 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Lars Kuhr 5/20/2026 09:44'
+	#'squeak_changestamp' : 'JS 6/23/2026 23:59'
 }
 SKPlayGround class >> newWithController: aController [
 

--- a/src/SqueakKara/SKSelectionModel.class.st
+++ b/src/SqueakKara/SKSelectionModel.class.st
@@ -52,16 +52,16 @@ SKSelectionModel >> items: aItemCollection [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 6/23/2026 16:16'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedIndex [
 
-	^ selectedIndex ifNil: [^ 1]
+	^ selectedIndex ifNil: [selectedIndex := 0]
 ]
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'Lars Kuhr 6/23/2026 16:03'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedIndex: aNumber [
 
@@ -70,11 +70,11 @@ SKSelectionModel >> selectedIndex: aNumber [
 
 {
 	#category : #accessing,
-	#'squeak_changestamp' : 'JS 6/23/2026 21:31'
+	#'squeak_changestamp' : 'Lars Kuhr 6/24/2026 11:40'
 }
 SKSelectionModel >> selectedValue [
 
-	self selectedIndex ifNil: [^''].
+	self selectedIndex = 0 ifTrue: [^''].
 	^ self items at: self selectedIndex
 ]
 

--- a/src/SqueakKara/SKStateMachineEditor.class.st
+++ b/src/SqueakKara/SKStateMachineEditor.class.st
@@ -345,7 +345,7 @@ SKStateMachineEditor >> initializeModeButtons [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'JS 6/23/2026 22:07'
+	#'squeak_changestamp' : 'JS 6/24/2026 00:03'
 }
 SKStateMachineEditor >> initializePlayground [
 

--- a/src/SqueakKara/SKStateMachineEditor.class.st
+++ b/src/SqueakKara/SKStateMachineEditor.class.st
@@ -345,7 +345,7 @@ SKStateMachineEditor >> initializeModeButtons [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'LP 6/17/2026 00:48'
+	#'squeak_changestamp' : 'JS 6/23/2026 22:07'
 }
 SKStateMachineEditor >> initializePlayground [
 
@@ -359,7 +359,7 @@ SKStateMachineEditor >> initializePlayground [
 	
 	startingNode := SKMealyNode newWithName: self nodeCounter asString.
 	self nodeCounterPP.
-	startingNode isStartingNode: true; isDraggable: false.
+	startingNode isStartingNode: true.
 	startingNode addMorph: (StringMorph new
 		contents: 'START';
 		color: Color black;


### PR DESCRIPTION
This branch added the following features and changes:

- Moveable start node
- Removed deleting nodes by dropping them outside the window
- Positioning entire node inside playground if only the center of the node is inbound when dropping the node
- Removed the isDroppable instance variable as its main use has been removed

Known improvements:
- The playground doesn't cover the entire window and thus is looks like a user is trying to drop a node inside the playground when in fact he is hovering on top of the state machine window.