### PR TITLE
Swt26 g07/ Refactoring: SKSystemWindow

### DIFF
--- a/src/SqueakKara/SKEnvironment.class.st
+++ b/src/SqueakKara/SKEnvironment.class.st
@@ -3,7 +3,7 @@ SKEnvironment provides the main programming environment, consisting of the grid 
 "
 Class {
 	#name : #SKEnvironment,
-	#superclass : #Object,
+	#superclass : #SKSystemWindow,
 	#instVars : [
 		'grid',
 		'karas',
@@ -77,13 +77,13 @@ SKEnvironment >> calculateScaleFactor: aPoint [
 
 {
 	#category : #commands,
-	#'squeak_changestamp' : 'LM 5/23/2026 13:45'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:10'
 }
 SKEnvironment >> close [
 
 	self grid abandon.
 	self executer terminate.
-	self systemWindow delete
+	self delete
 ]
 
 {
@@ -262,7 +262,7 @@ SKEnvironment >> initializeLandingPage [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'LM 5/21/2026 10:46'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:09'
 }
 SKEnvironment >> initializeObjects [
 
@@ -270,7 +270,7 @@ SKEnvironment >> initializeObjects [
 	self executeControls environment: self.
 	
 	self setSystemWindow.
-	self systemWindow openInHand
+	self openInHand
 ]
 
 {
@@ -513,27 +513,27 @@ SKEnvironment >> pause [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'LM 4/28/2026 20:46'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:08'
 }
 SKEnvironment >> positionExecuteControlsAndGrid [
 
 	| startPoint |
 	
 	startPoint  := self grid pixelPerBlock @ (3 * self grid pixelPerBlock).
-	self grid position: self systemWindow position + startPoint.
+	self grid position: self position + startPoint.
 	
 	startPoint := ((self gameWidth / 2) - (self executeControls width / 2)) @ ( 1.5 * self grid pixelPerBlock).
-	self executeControls position: self systemWindow position + startPoint.
+	self executeControls position: self position + startPoint.
 ]
 
 {
 	#category : #layout,
-	#'squeak_changestamp' : 'LM 4/29/2026 12:26'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:08'
 }
 SKEnvironment >> resize [
 	
 	| scaleFactor |
-	scaleFactor := self calculateScaleFactor: self systemWindow extent.
+	scaleFactor := self calculateScaleFactor: self extent.
 	
 	self resizeGridByFactor: scaleFactor.
 	self executeControls scaleFactor: scaleFactor
@@ -570,22 +570,20 @@ SKEnvironment >> run [
 
 {
 	#category : #initialization,
-	#'squeak_changestamp' : 'jawi 6/3/2026 19:53'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:08'
 }
 SKEnvironment >> setSystemWindow [
 	
 	| container |
 	
-	self systemWindow: SKSystemWindow new.
-	self systemWindow setLabel: 'Kara'.
+	self setLabel: 'Kara'.
 	
 	container := self containerMorph
 		addMorph: self grid;
 		addMorph: self executeControls;
 		yourself.
 	
-	self systemWindow
-		extent: self gameWidth @ self gameHeight;
+	self extent: self gameWidth @ self gameHeight;
 		setWindowColor: self grid backgroundColor;
 		resizeListener: [ self resize ];
 		closeListener: [ self abandon ];

--- a/src/SqueakKara/SKEnvironment.class.st
+++ b/src/SqueakKara/SKEnvironment.class.st
@@ -11,7 +11,6 @@ Class {
 		'executeControls',
 		'gameWidth',
 		'gameHeight',
-		'systemWindow',
 		'nextChallenge',
 		'currentChallenge'
 	],
@@ -600,24 +599,6 @@ SKEnvironment >> setSystemWindow [
 SKEnvironment >> stop [
 	
 	self executer terminate
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'JJG 7/1/2024 16:11'
-}
-SKEnvironment >> systemWindow [
-	
-	^ systemWindow
-]
-
-{
-	#category : #accessing,
-	#'squeak_changestamp' : 'JJG 7/1/2024 16:10'
-}
-SKEnvironment >> systemWindow: anObject [
-	
-	systemWindow := anObject
 ]
 
 {

--- a/src/SqueakKara/SKLandingPage.class.st
+++ b/src/SqueakKara/SKLandingPage.class.st
@@ -3,7 +3,7 @@ SKLandingPage provides a user interface for the user to select either a blank wo
 "
 Class {
 	#name : #SKLandingPage,
-	#superclass : #SystemWindow,
+	#superclass : #SKSystemWindow,
 	#category : #SqueakKara,
 	#'squeak_changestamp' : 'JJG 7/1/2024 16:01'
 }

--- a/src/SqueakKaraTests/SKExecuteControlsTest.class.st
+++ b/src/SqueakKaraTests/SKExecuteControlsTest.class.st
@@ -45,17 +45,17 @@ SKExecuteControlsTest >> testMaxNumberRandomKaraSpawn [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'ND 6/18/2026 21:57'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:12'
 }
 SKExecuteControlsTest >> testNextChallenge [
 	
 	| world testEnvironment testEnvironmentNew |
 	
 	testEnvironment := SKEnvironment new initializeWithChallenge1.
-	world := testEnvironment systemWindow owner.
+	world := testEnvironment owner.
 	testEnvironment executeControls addButtonNextChallenge.
 	
-	self assert: (world submorphs includes: (testEnvironment systemWindow)).
+	self assert: (world submorphs includes: (testEnvironment)).
 	
 	testEnvironmentNew := testEnvironment executeControls buttonNextChallenge action.
 	

--- a/src/SqueakKaraTests/SKExecuteControlsTest.class.st
+++ b/src/SqueakKaraTests/SKExecuteControlsTest.class.st
@@ -45,7 +45,7 @@ SKExecuteControlsTest >> testMaxNumberRandomKaraSpawn [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'ND 7/1/2026 16:12'
+	#'squeak_changestamp' : 'ND 7/1/2026 16:20'
 }
 SKExecuteControlsTest >> testNextChallenge [
 	
@@ -59,7 +59,7 @@ SKExecuteControlsTest >> testNextChallenge [
 	
 	testEnvironmentNew := testEnvironment executeControls buttonNextChallenge action.
 	
-	self deny: (world submorphs includes: (testEnvironment systemWindow)).
+	self deny: (world submorphs includes: (testEnvironment)).
 	
 	testEnvironmentNew close
 ]


### PR DESCRIPTION
SKSystemWindow is now used in Landing Page instead of squeaks SystemWindow. Environment does now inherit this class and therefore removed the instance variable of systemWidow.